### PR TITLE
Fix lingeling:2014

### DIFF
--- a/2014/solvers.json
+++ b/2014/solvers.json
@@ -143,7 +143,7 @@
     },
     "lingeling": {
 	      "tracks" : ["application", "crafted"],
-        "status":"error: invalid command line option '--drupligtrace'",
+        "status": "ok",
         "args": [
             "-v",
             "--witness",
@@ -152,8 +152,7 @@
         "argsproof" : [
             "-v",
             "--druplig",
-            "FILECNF",
-            "--drupligtrace"
+            "FILECNF"
         ],
         "authors": "Armin Biere",
         "call": "./lingeling",


### PR DESCRIPTION
In proof mode, `lingeling:2014` was set using `--drupligtrace` option, however, it is unknown by the program.

This PR removes this unknown option, but it would be great to double check the command.

The command used in non-proof mode is
`./lingeling -v --witness FILECNF`

In non-proof mode (fixed):
`./lingeling -v --druplig FILECNF`